### PR TITLE
fix: Dependency issue

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,30 +62,6 @@
         "type": "github"
       }
     },
-    "cachix-deploy-flake": {
-      "inputs": {
-        "darwin": "darwin",
-        "disko": "disko",
-        "home-manager": "home-manager",
-        "nixos-anywhere": "nixos-anywhere",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1725305631,
-        "narHash": "sha256-RcpR2sN4BlNW6lEOIsa119QqgANsZM4Lrs1FnPSEHic=",
-        "owner": "cachix",
-        "repo": "cachix-deploy-flake",
-        "rev": "aaca8c67c1d86fc3908ff0c471991a08e829426e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "cachix-deploy-flake",
-        "type": "github"
-      }
-    },
     "catppuccin": {
       "locked": {
         "lastModified": 1725509983,
@@ -120,27 +96,6 @@
       }
     },
     "darwin": {
-      "inputs": {
-        "nixpkgs": [
-          "cachix-deploy-flake",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1715871485,
-        "narHash": "sha256-ywapEXmBBI+DVRx/YYC6+6Lk+W8vhShz1uJNvqPKzng=",
-        "owner": "LnL7",
-        "repo": "nix-darwin",
-        "rev": "cb02884fa1ff5a619a44ab5f1bcc4dedd2d623c2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "LnL7",
-        "repo": "nix-darwin",
-        "type": "github"
-      }
-    },
-    "darwin_2": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
@@ -181,27 +136,6 @@
       }
     },
     "disko": {
-      "inputs": {
-        "nixpkgs": [
-          "cachix-deploy-flake",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1715822638,
-        "narHash": "sha256-Z4ZoyK8jYRmBZwMaEZLEmAilrfdpekwwwohliqC14/E=",
-        "owner": "nix-community",
-        "repo": "disko",
-        "rev": "476eef8d85aa09389ae7baf6e6b60357f6a01432",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "disko",
-        "type": "github"
-      }
-    },
-    "disko_2": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
@@ -440,28 +374,6 @@
     "flake-parts_3": {
       "inputs": {
         "nixpkgs-lib": [
-          "cachix-deploy-flake",
-          "nixos-anywhere",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1701473968,
-        "narHash": "sha256-YcVE5emp1qQ8ieHUnxt1wCZCC3ZfAS+SRRWZ2TMda7E=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "34fed993f1674c8d06d58b37ce1e0fe5eebcb9f5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_4": {
-      "inputs": {
-        "nixpkgs-lib": [
           "neovim-nightly-overlay",
           "nixpkgs"
         ]
@@ -480,7 +392,7 @@
         "type": "github"
       }
     },
-    "flake-parts_5": {
+    "flake-parts_4": {
       "inputs": {
         "nixpkgs-lib": [
           "neovim-nightly-overlay",
@@ -766,7 +678,7 @@
     },
     "hercules-ci-effects": {
       "inputs": {
-        "flake-parts": "flake-parts_5",
+        "flake-parts": "flake-parts_4",
         "nixpkgs": [
           "neovim-nightly-overlay",
           "nixpkgs"
@@ -789,36 +701,15 @@
     "home-manager": {
       "inputs": {
         "nixpkgs": [
-          "cachix-deploy-flake",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1715486357,
-        "narHash": "sha256-4pRuzsHZOW5W4CsXI9uhKtiJeQSUoe1d2M9mWU98HC4=",
+        "lastModified": 1726222338,
+        "narHash": "sha256-KuA8ciNR8qCF3dQaCaeh0JWyQUgEwkwDHr/f49Q5/e8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "44677a1c96810a8e8c4ffaeaad10c842402647c1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "type": "github"
-      }
-    },
-    "home-manager_2": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1726221057,
-        "narHash": "sha256-E0JYRNOcPNNVpgg/xrCyqH/Go2laDs6EOqxSieam9hI=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "7923c691527d2ee85fe028c6e780ac3bf8606f06",
+        "rev": "503af483e1b328691ea3a434d331995595fb2e3d",
         "type": "github"
       },
       "original": {
@@ -924,11 +815,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726159284,
-        "narHash": "sha256-6xatk6CPY1F6xHF1gLGz7QExftEhV8Q5fI4BqVBVF3U=",
+        "lastModified": 1726246604,
+        "narHash": "sha256-cScS34F71HzhIUeMScfKrT7iSZA0tr8pGIjOqHF+ue8=",
         "ref": "refs/heads/main",
-        "rev": "118be4dea048df88fd21b84580fe62950c868c8f",
-        "revCount": 5215,
+        "rev": "d35e70a8c6599bb058cf86eb87c783ce1cf72471",
+        "revCount": 5218,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/hyprwm/Hyprland"
@@ -1438,7 +1329,7 @@
     "neovim-nightly-overlay": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-parts": "flake-parts_4",
+        "flake-parts": "flake-parts_3",
         "git-hooks": "git-hooks",
         "hercules-ci-effects": "hercules-ci-effects",
         "neovim-src": "neovim-src",
@@ -1516,114 +1407,6 @@
         "type": "github"
       }
     },
-    "nixlib": {
-      "locked": {
-        "lastModified": 1725757153,
-        "narHash": "sha256-c1a6iLmCVPFI9EUVMrBN8xdmFxFXEjcVwiTSVmqajOs=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "68584f89dd0eb16fea5d80ae127f3f681f6a5df7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixos-anywhere": {
-      "inputs": {
-        "disko": [
-          "cachix-deploy-flake",
-          "disko"
-        ],
-        "flake-parts": "flake-parts_3",
-        "nixos-images": "nixos-images",
-        "nixos-stable": "nixos-stable",
-        "nixpkgs": [
-          "cachix-deploy-flake",
-          "nixpkgs"
-        ],
-        "treefmt-nix": "treefmt-nix"
-      },
-      "locked": {
-        "lastModified": 1715150548,
-        "narHash": "sha256-pb2xIGuzzkPOjUlZnBahpfQWVvtCSOcW8vLL7rQUiEY=",
-        "owner": "numtide",
-        "repo": "nixos-anywhere",
-        "rev": "242444d228636b1f0e89d3681f04a75254c29f66",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "nixos-anywhere",
-        "type": "github"
-      }
-    },
-    "nixos-generators": {
-      "inputs": {
-        "nixlib": "nixlib",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1726102718,
-        "narHash": "sha256-u89QyfjtXryLHrO3Wre4kuWK5KDKiXe8lgRi6+cUOEw=",
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "rev": "5ae384b83b91080f0fead6bc1add1cff8277cb3f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "type": "github"
-      }
-    },
-    "nixos-images": {
-      "inputs": {
-        "nixos-2311": [
-          "cachix-deploy-flake",
-          "nixos-anywhere",
-          "nixos-stable"
-        ],
-        "nixos-unstable": [
-          "cachix-deploy-flake",
-          "nixos-anywhere",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1702375325,
-        "narHash": "sha256-kEdrh6IB7xh7YDwZ0ZVCngCs+uoS9gx4ydEoJRnM1Is=",
-        "owner": "nix-community",
-        "repo": "nixos-images",
-        "rev": "d655cc02fcb9ecdcca4f3fb307e291a4b5be1339",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixos-images",
-        "type": "github"
-      }
-    },
-    "nixos-stable": {
-      "locked": {
-        "lastModified": 1702233072,
-        "narHash": "sha256-H5G2wgbim2Ku6G6w+NSaQaauv6B6DlPhY9fMvArKqRo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "781e2a9797ecf0f146e81425c822dca69fe4a348",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-23.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixos-wsl": {
       "inputs": {
         "flake-compat": "flake-compat_5",
@@ -1680,22 +1463,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-small": {
-      "locked": {
-        "lastModified": 1726167369,
-        "narHash": "sha256-HESGBMdDP5NweNsfCmifXsmYg66EPRseEriIU9vbkog=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "c7b929cfd422f37173be14f0787decb6b06aa34c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable-small",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1720386169,
@@ -1724,6 +1491,22 @@
       "original": {
         "owner": "NixOS",
         "ref": "release-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1726206720,
+        "narHash": "sha256-tI7141IHDABMNgz4iXDo8agCp0SeTLbaIZ2DRndwcmk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "673d99f1406cb09b8eb6feab4743ebdf70046557",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1807,11 +1590,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1725983898,
-        "narHash": "sha256-4b3A9zPpxAxLnkF9MawJNHDtOOl6ruL0r6Og1TEDGCE=",
+        "lastModified": 1726062873,
+        "narHash": "sha256-IiA3jfbR7K/B5+9byVi9BZGWTD4VSbWe8VLpp9B/iYk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1355a0cbfeac61d785b7183c0caaec1f97361b43",
+        "rev": "4f807e8940284ad7925ebd0a0993d2a1791acb2f",
         "type": "github"
       },
       "original": {
@@ -1855,11 +1638,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1726218930,
-        "narHash": "sha256-zi+iz7bOmvbNnQphqVUjmJdNdWJAu5g17pPjGFYyu9g=",
+        "lastModified": 1726295979,
+        "narHash": "sha256-8sFBoKCytkGCTBmZdxk16SbUiE4g4jLurBuDKFvxe1s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7a5f7863d2f2587993c87a5a575cfc2c802defac",
+        "rev": "c562f0c8401ece326f572b81b7188b05acfc65e7",
         "type": "github"
       },
       "original": {
@@ -1894,14 +1677,13 @@
         "anyrun": "anyrun",
         "anyrun-nixos-options": "anyrun-nixos-options",
         "aquamarine": "aquamarine",
-        "cachix-deploy-flake": "cachix-deploy-flake",
         "catppuccin": "catppuccin",
         "catppuccin-cursors": "catppuccin-cursors",
-        "darwin": "darwin_2",
+        "darwin": "darwin",
         "deploy-rs": "deploy-rs",
-        "disko": "disko_2",
+        "disko": "disko",
         "gpg-base-conf": "gpg-base-conf",
-        "home-manager": "home-manager_2",
+        "home-manager": "home-manager",
         "hypr-socket-watch": "hypr-socket-watch",
         "hypridle": "hypridle",
         "hyprland": "hyprland",
@@ -1915,10 +1697,9 @@
         "neovim-nightly-overlay": "neovim-nightly-overlay",
         "nix-index-database": "nix-index-database",
         "nix-ld-rs": "nix-ld-rs",
-        "nixos-generators": "nixos-generators",
         "nixos-wsl": "nixos-wsl",
         "nixpkgs": "nixpkgs_7",
-        "nixpkgs-small": "nixpkgs-small",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "nur": "nur",
         "pre-commit-hooks": "pre-commit-hooks",
         "snowfall-flake": "snowfall-flake",
@@ -2068,11 +1849,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726201008,
-        "narHash": "sha256-qiW2nZ6yo2NdkoH0+K2/p4eUElEtWIOo711dOB4rJhg=",
+        "lastModified": 1726287383,
+        "narHash": "sha256-20DoHPEml+by2U2yja09tprLDFcimQAeL7kDIjLtyeo=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "856a4212b354cfa1f1c747691e1ddf37ff9b1984",
+        "rev": "bb37104c197760c5cfca571036a1d011c4c92754",
         "type": "github"
       },
       "original": {
@@ -2333,28 +2114,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default-linux",
-        "type": "github"
-      }
-    },
-    "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "cachix-deploy-flake",
-          "nixos-anywhere",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1702376629,
-        "narHash": "sha256-9uAY8a7JN4DvLe/g4OoldqPbcNZ09YOVXID+CkIqL70=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "390018a9398f9763bfc05ffe6443ce0622cb9ba6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,10 +7,10 @@
     anyrun-nixos-options.url = "github:n3oney/anyrun-nixos-options";
 
     # Cachix agent for caching binaries
-    cachix-deploy-flake = {
-      url = "github:cachix/cachix-deploy-flake";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    # cachix-deploy-flake = {
+    #   url = "github:cachix/cachix-deploy-flake";
+    #   inputs.nixpkgs.follows = "nixpkgs";
+    # };
 
     # Theme - Catppuccin
     catppuccin-cursors.url = "github:catppuccin/cursors";
@@ -137,16 +137,16 @@
       url = "github:nixos/nixpkgs/nixos-unstable";
     };
 
-    # NixPkgs (nixos-unstable)
-    nixpkgs-small = {
-      url = "github:nixos/nixpkgs/nixos-unstable-small";
+    # NixPkgs (nixpkgs-unstable)
+    nixpkgs-unstable = {
+      url = "github:nixos/nixpkgs/nixpkgs-unstable";
     };
 
     # Build system images and artifacts supported by nixos-generators.
-    nixos-generators = {
-      url = "github:nix-community/nixos-generators";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    # nixos-generators = {
+    #   url = "github:nix-community/nixos-generators";
+    #   inputs.nixpkgs.follows = "nixpkgs";
+    # };
 
     # NixOS WSL Support
     nixos-wsl = {
@@ -254,7 +254,7 @@
 
       systems = {
         modules = {
-          nixos = with inputs; [ ];
+          nixos = [ ];
         };
       };
 

--- a/modules/home/suites/common/default.nix
+++ b/modules/home/suites/common/default.nix
@@ -87,7 +87,7 @@ in
             ripgrep = enabled;
             tmux = enabled;
             # topgrade = enabled;
-            yazi = enabled;
+            # yazi = enabled;
             # zellij = enabled;
             zoxide = enabled;
           };

--- a/modules/home/suites/development/default.nix
+++ b/modules/home/suites/development/default.nix
@@ -42,6 +42,7 @@ in
           nixpkgs-lint-community
           nixpkgs-review
           nix-update
+          nix-init
         ]
         ++ lib.optionals cfg.game.enable [
           godot_4

--- a/modules/home/suites/music/default.nix
+++ b/modules/home/suites/music/default.nix
@@ -35,10 +35,10 @@ in
 
     space = {
       programs.terminal = {
-        media = {
-          ncmpcpp = enabled;
-          ncspot = enabled;
-        };
+        # media = {
+        #   ncmpcpp = enabled;
+        #   ncspot = enabled;
+        # };
 
         tools = {
           cava = enabled;

--- a/modules/home/user/default.nix
+++ b/modules/home/user/default.nix
@@ -87,6 +87,7 @@ in
         shellAliases = {
           # nix specific aliases
           cleanup = "sudo nix-collect-garbage --delete-older-than 3d && nix-collect-garbage -d";
+          optimise = "nix-store --optimise -vv";
           bloat = "nix path-info -Sh /run/current-system";
           curgen = "sudo nix-env --list-generations --profile /nix/var/nix/profiles/system";
           gc-check = ''nix-store --gc --print-roots | egrep -v "^(/nix/var|/run/w+-system|{memory|/proc)"'';
@@ -97,6 +98,30 @@ in
           nixre = "${lib.optionalString pkgs.stdenv.isLinux "sudo"} ${
             getExe snowfall-flake.packages.${system}.flake
           } switch";
+          reload = # bash
+            ''
+              echo "[i] This command will run the following commands: "
+              echo "[i]   1. 'nix-collect-garbage --delete-older-than 3d && nix-collect-garbage -d'"
+              echo "[i]   2. 'nix-store --verify --check-contents --repair'"
+              echo "[i]   3. 'nix-store --optimise -vv'"
+              echo "[i] Essentially, clean, repair and optimise nix-store."
+              echo ""
+              read -e -p "[?] Run commands? " choice
+              if [[ "$choice" == [yY]+ ]]; then
+                echo "[!] Running 'nix-collect-garbage --delete-older-than 3d && nix-collect-garbage-d'"
+                nix-collect-garbage --delete-older-than 3d && nix-collect-garbage -d
+
+                echo "[!] Running 'nix-store --verify --check-contents --repair'"
+                nix-store --verify --check-contents --repair
+
+                echo "[!] Running 'nix-store --optimise -vv'"
+                nix-store --optimise -vv
+
+                echo "[i] Done."
+              else
+                echo "[!] Aborted!"
+              fi
+            '';
 
           gsed = "${getExe pkgs.gnused}";
 

--- a/modules/shared/nix/default.nix
+++ b/modules/shared/nix/default.nix
@@ -40,20 +40,17 @@ in
         cachix
         deploy-rs
         git
-        nix-prefetch-scripts # includes git, svn, hg, etc.
-        nix-prefetch-docker # scripts doesn't include docker.
-        nix-init
-        nix-update
+        nix-prefetch-git
       ];
     };
 
     nix =
       let
-        mappedRegistry = lib.pipe inputs [
-          (lib.filterAttrs (_: lib.isType "flake"))
-          (lib.mapAttrs (_: flake: { inherit flake; }))
-          (x: x // { nixpkgs.flake = inputs.nixpkgs; })
-        ];
+        # mappedRegistry = lib.pipe inputs [
+        #   (lib.filterAttrs (_: lib.isType "flake"))
+        #   (lib.mapAttrs (_: flake: { inherit flake; }))
+        #   (x: x // { nixpkgs.flake = inputs.nixpkgs; })
+        # ];
 
         users = [
           "root"
@@ -78,7 +75,14 @@ in
 
         # pin the registry to avoid downloading and evaluating a new nixpkgs version every time
         # this will add each flake input as a registry to make nix3 commands consistent with your flake
-        registry = mappedRegistry;
+        # registry = mappedRegistry;
+        registry = {
+          nixpkgs = {
+            to = {
+              path = lib.mkForce inputs.nixpkgs;
+            };
+          };
+        };
 
         settings = {
           allowed-users = users;
@@ -98,7 +102,7 @@ in
 
           substituters = [
             "https://cache.nixos.org"
-            # "https://space.cachix.org"
+            "https://space.cachix.org"
             "https://nix-community.cachix.org"
             "https://nixpkgs-unfree.cachix.org"
             "https://numtide.cachix.org"
@@ -106,7 +110,7 @@ in
 
           trusted-public-keys = [
             "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
-            # "space.cachix.org-1:3mthjI+T4B8dAu6Q2fn4/2Lqcywg4F0n12m9K2y3PlU="
+            "space.cachix.org-1:3mthjI+T4B8dAu6Q2fn4/2Lqcywg4F0n12m9K2y3PlU="
             "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
             "nixpkgs-unfree.cachix.org-1:hqvoInulhbV4nJ9yJOEr+4wxhDV4xq2d1DK7S6Nj6rs="
             "numtide.cachix.org-1:2ps1kLBUWjxIneOy1Ik6cQjb41X0iXVXeHigGmycPPE="

--- a/overlays/svn/default.nix
+++ b/overlays/svn/default.nix
@@ -1,0 +1,12 @@
+_: _final: prev: {
+  # TODO: remove after https://github.com/NixOS/nixpkgs/pull/341232 is available
+  subversionClient = prev.subversionClient.overrideAttrs (_oldAttrs: {
+    env = prev.lib.optionalAttrs prev.stdenv.cc.isClang {
+      NIX_CFLAGS_COMPILE = toString [
+        "-Wno-error=implicit-function-declaration"
+        "-Wno-error=implicit-int"
+        "-Wno-int-conversion"
+      ];
+    };
+  });
+}


### PR DESCRIPTION
Issue appeared after running `flake update`.

`nix config check` displayed a minor issues with 2 `nix` binary installs with same version. After resolving that, issue still persisted.

Deleting and re-creating the `flake.lock` file via many of the nix flake commands didn't help. Additionally, restarting the shell, terminal or computer did not help either.

I think one of the issues were caused by one or multiple flakes in the registry (assigned within `<root>/modules/shared/nix/default.nix`).

While I'm not entirely sure if they helped, running the three commands which is used within my `reload`-script (`<root>/modules/home/user/default.nix`) seems to have resolved the issue. The script runs the following commands:
  1. `nix-collect-garbage --delete-older-than 3d && nix-collect-garbage -d`
  2. `nix-store --verify --check-contents --repair`
  3. `nix-store --optimise -vv`

These three commands can be summed up to be: cleaning, repairing and optimizing the nix-store.