### PR TITLE
feat(modules): add ttyper (cli) and firefox (dev edition)

### DIFF
--- a/configs/nvim/lazy-lock.json
+++ b/configs/nvim/lazy-lock.json
@@ -1,7 +1,7 @@
 {
   "LazyVim": {
     "branch": "main",
-    "commit": "d5a4ced75acadb6ae151c0d2960a531c691c88b9"
+    "commit": "13a4a84e3485a36e64055365665a45dc82b6bf71"
   },
   "LuaSnip": {
     "branch": "master",
@@ -25,11 +25,11 @@
   },
   "catppuccin": {
     "branch": "main",
-    "commit": "63685e1562ef53873c9764b483d7ac5c7a608922"
+    "commit": "7be452ee067978cdc8b2c5f3411f0c71ffa612b9"
   },
   "clangd_extensions.nvim": {
     "branch": "main",
-    "commit": "385a44f133f4145e3a3da1a2a557225dccc3e1f8"
+    "commit": "8f7b72100883e0e34400d9518d40a03f21e4d0a6"
   },
   "cmp-buffer": {
     "branch": "main",
@@ -77,7 +77,7 @@
   },
   "everforest-nvim": {
     "branch": "main",
-    "commit": "308c024bc1fcb7e179eb9551ba5f69dae1737d2b"
+    "commit": "7c57941d5ef5a150f307b9295c00a59e95d78587"
   },
   "flash.nvim": {
     "branch": "main",
@@ -85,7 +85,7 @@
   },
   "friendly-snippets": {
     "branch": "main",
-    "commit": "00ba9dd3df89509f95437b8d595553707c46d5ea"
+    "commit": "de8fce94985873666bd9712ea3e49ee17aadb1ed"
   },
   "gitsigns.nvim": {
     "branch": "main",
@@ -93,7 +93,7 @@
   },
   "grug-far.nvim": {
     "branch": "main",
-    "commit": "b7c2b28e49d55ff71cd9bb3ad19a2021316510d8"
+    "commit": "75aad2698d428bdc94ff15f487f7165aee8ccbfb"
   },
   "inc-rename.nvim": {
     "branch": "main",
@@ -101,11 +101,11 @@
   },
   "indent-blankline.nvim": {
     "branch": "master",
-    "commit": "3af6493bf69e4a857a8b1fab36f333629d413a18"
+    "commit": "e7a4442e055ec953311e77791546238d1eaae507"
   },
   "kulala.nvim": {
     "branch": "main",
-    "commit": "39ce81edc135c21800d03333eb1e7625b8d03f70"
+    "commit": "f7186ec0909f820945f1cfb77bf83a12935f62d8"
   },
   "lazy.nvim": {
     "branch": "main",
@@ -161,7 +161,7 @@
   },
   "mini.pairs": {
     "branch": "main",
-    "commit": "919a89ed3c9f4142215a44c9fffca72fa8c8e792"
+    "commit": "694d9beb488ff1afaf3d1977b067e53c827d9af5"
   },
   "mini.surround": {
     "branch": "main",
@@ -169,7 +169,7 @@
   },
   "neoconf.nvim": {
     "branch": "main",
-    "commit": "34c822ef117dced4658cfef8803e615128528f3d"
+    "commit": "d222cd70d143859dec77166181e9b96a87d36113"
   },
   "neogen": {
     "branch": "main",
@@ -229,7 +229,7 @@
   },
   "nvim-lspconfig": {
     "branch": "master",
-    "commit": "39f31e178466e4ed23c8ea6fddd5b7a4d9699398"
+    "commit": "d3f169f436e1b44538bfe7e13b4721eec48dbc59"
   },
   "nvim-nio": {
     "branch": "master",
@@ -249,7 +249,7 @@
   },
   "nvim-treesitter": {
     "branch": "master",
-    "commit": "45386764cc9535200d2288cab929c5093d33660e"
+    "commit": "9d2acd49976e2a9da72949008df03436f781fd23"
   },
   "nvim-treesitter-context": {
     "branch": "master",
@@ -261,7 +261,7 @@
   },
   "nvim-treesitter-textobjects": {
     "branch": "master",
-    "commit": "4a2d05ec24eaa6b655c7d19092a3b6c0219d46b9"
+    "commit": "b91c98afa6c42819aea6cbc1ba38272f5456a5cf"
   },
   "nvim-ts-autotag": {
     "branch": "main",
@@ -269,7 +269,7 @@
   },
   "nvim-ts-context-commentstring": {
     "branch": "main",
-    "commit": "44fd461b879d80a21d5041f312f070f22551c0bc"
+    "commit": "9c74db656c3d0b1c4392fc89a016b1910539e7c0"
   },
   "octo.nvim": {
     "branch": "master",
@@ -297,11 +297,11 @@
   },
   "render-markdown.nvim": {
     "branch": "main",
-    "commit": "fe1002fddc61207e4ef4325d4bc0ca33697bbc7a"
+    "commit": "d20d19fa54965f6eb94558c0b84fe9a942169fb4"
   },
   "rustaceanvim": {
     "branch": "master",
-    "commit": "29f42cc149f915d771c550b6dfe7c788d856cf04"
+    "commit": "d1f56672638508a7bc971cde31a29df4018579a9"
   },
   "snippet-converter.nvim": {
     "branch": "main",
@@ -329,7 +329,7 @@
   },
   "telescope.nvim": {
     "branch": "master",
-    "commit": "eae0d8fbde590b0eaa2f9481948cd6fd7dd21656"
+    "commit": "dc6fc321a5ba076697cca89c9d7ea43153276d81"
   },
   "todo-comments.nvim": {
     "branch": "main",

--- a/modules/darwin/suites/desktop/default.nix
+++ b/modules/darwin/suites/desktop/default.nix
@@ -43,6 +43,7 @@ in
         "appcleaner"
         "bartender"
         "brave-browser"
+        "firefox@developer-edition"
         "gpg-suite"
         "launchcontrol"
         "monitorcontrol"

--- a/modules/home/suites/development/default.nix
+++ b/modules/home/suites/development/default.nix
@@ -35,6 +35,7 @@ in
           postman
           silicon
           tree-sitter
+          ttyper
           vscode
         ]
         ++ lib.optionals pkgs.stdenv.isLinux [


### PR DESCRIPTION
Update to modules.

### Adds

- [ttyper](https://github.com/max-niederman/ttyper) (CLI). Terminal-based typing test.
- [Firefox Developer Edition](https://www.mozilla.org/en-US/firefox/developer/) (Browser) via [Homebrew](https://formulae.brew.sh/cask/firefox@developer-edition).